### PR TITLE
Added support for windows 7 (local GPO) - wip

### DIFF
--- a/powershell/setup-defender.ps1
+++ b/powershell/setup-defender.ps1
@@ -16,6 +16,28 @@ Param(
 $tmpPath = $path
 $tmpPath += "\tmp"
 
+function Add-WindowsDefenderExclusionsPolicy([string]$pathToAdd)
+{                  
+    $registryKey = "HKLM:\SOFTWARE\Policies\Microsoft\Windows Defender\Exclusions\Paths" 
+       
+    $found = $False
+    
+    $items = Get-Item $registryKey
+        
+    Foreach ($name in $items.GetValueNames()) {
+        if ([string]::Compare($name, $pathToAdd, $True) -eq 0) {
+            # Path already added
+            Write-Host "Path already added to exclusion list"
+            return
+        }
+    }
+            
+    Set-ItemProperty -Path $registryKey -Name $pathToAdd -Value 0 -Force
+    Write-Host "Path added to defender exclusion list, updating policy"
+            
+    gpupdate | Out-Null
+}
+
 function IsAdministrator
 {
     $Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
@@ -48,12 +70,26 @@ if (!(IsAdministrator))
     }
 }
 
+
+
 # Set preference
 "Removing " + $path + " from Windows Defender's Eye"
-if (Get-Command Set-MpPreference -errorAction SilentlyContinue) {
+
+
+# https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832%28v=vs.85%29.aspx
+$version = [Environment]::OSVersion.Version
+
+if ($version.Major -eq 6 -AND $version.Minor -gt 1) {
+  # Windows 8 and above
+  if (Get-Command Set-MpPreference -errorAction SilentlyContinue) {
     Set-MpPreference -ExclusionPath $path
-} else {
+  } else {
     "Defender Configuration not available, fallback required"
+  }  
+}
+elseif ($version.Major -eq 6 -AND $version.Minor -eq 1) {
+  # Windows 7 / Server 2008 R2
+  Add-WindowsDefenderExclusionsPolicy $path
 }
 
 "Done"

--- a/powershell/setup-defender.ps1
+++ b/powershell/setup-defender.ps1
@@ -79,7 +79,7 @@ if (!(IsAdministrator))
 # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832%28v=vs.85%29.aspx
 $version = [Environment]::OSVersion.Version
 
-if ($version.Major -eq 6 -AND $version.Minor -gt 1) {
+if (($version.Major -eq 6 -AND $version.Minor -gt 1) -or ($version.Major -gt 6)) {
   # Windows 8 and above
   if (Get-Command Set-MpPreference -errorAction SilentlyContinue) {
     Set-MpPreference -ExclusionPath $path


### PR DESCRIPTION
To be perfectly honest: PowerShell is not feeling home to me, so please handle with care. It seems to be working for me, the exclusion is added to the options.

Caveats:
You cannot delete the path from the options via GUI (they will just reappear, apparently local GPO will just override that option). It can be removed via regedit.exe though.
I don't have a windows 8 system for test available right now, so hopefully I did not break the existing functionality.
