### PR TITLE
Execute powershell without a profile

### DIFF
--- a/bin/ember-cli-windows
+++ b/bin/ember-cli-windows
@@ -12,7 +12,7 @@ var spawn = require('child_process').spawn,
 
 // Helper functions
 function runPowershell(scriptPath, name, cb) {
-    var child = spawn('powershell.exe', [scriptPath]),
+    var child = spawn('powershell.exe', ['-NoProfile', '-NoLogo', scriptPath]),
         output = [];
 
     child.stdout.on('data', function (data) {


### PR DESCRIPTION
As we have no need for any profile configurations, execute the process faster by skipping loading of any profile. 

I personally list all the subfolders in my projects root with my profile so this stops `ls` running 3 times with about 40 items.

This also bypasses writing microsofts branding to screen in an effort to speed up a bit further.
