### PR TITLE
Fix setup-search.ps1 exception on Win7.

### DIFF
--- a/powershell/setup-search.ps1
+++ b/powershell/setup-search.ps1
@@ -27,7 +27,7 @@ $catalog = $sm.GetCatalog("SystemIndex")
 $crawlman = $catalog.GetCrawlScopeManager()
 
 # Add Folders to Rules
-$crawlman.AddUserScopeRule($tmpPath,$false,$true,$null)
+$crawlman.AddUserScopeRule($tmpPath,$false,$false,$null)
 $crawlman.SaveAll()
 
 "Done"


### PR DESCRIPTION
I'm back again with another fix for Win7 SP1. I've kept getting the following exception:

![capture](https://cloud.githubusercontent.com/assets/613647/6708905/e5179d7e-cd74-11e4-8f33-64b3bd00bcd1.PNG)

Turns out it is caused by the third argument (override children) being `$true` when adding path exclusion rule. The only way I was able to get it to work properly was to provide `$false` as a third argument. One might think that it will cause trouble with child folders but I have performed extensive testing and seems it works as expected (probably because of a wildcard in the path which anyway overrides other rules).

![capture](https://cloud.githubusercontent.com/assets/613647/6709090/6e511b0a-cd76-11e4-9f5c-61603982b4ae.PNG)

Anyway if anybody has Win8 or/and Win8.1 at hand, please try it on your machine too. I can test it on Win8.1 today after work and will come back with the result.
