### PR TITLE
Mark package as Windows-specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "ember-cli-windows",
   "version": "2.1.1",
+  "os": [
+    "win32"
+  ],
   "private": false,
   "preferGlobal": "true",
   "bin": {


### PR DESCRIPTION
This allows the package to be marked as an optionalDependency in dependents which won't install on OSX / nix.
