### PR TITLE
Replace Set-MpPreference with Add-MpPreference

### DIFF
--- a/powershell/setup-defender.ps1
+++ b/powershell/setup-defender.ps1
@@ -92,9 +92,9 @@ $version = [Environment]::OSVersion.Version
 if (($version.Major -eq 6 -AND $version.Minor -gt 1) -or ($version.Major -gt 6))
 {
     # Windows 8 and above
-    if (Get-Command Set-MpPreference) {
+    if (Get-Command Add-MpPreference) {
         Try {
-            Set-MpPreference -ExclusionPath $path -ErrorAction Stop
+            Add-MpPreference -ExclusionPath $path -ErrorAction Stop
         } Catch {
             "Defender Configuration not available, is it disabled?"
         }


### PR DESCRIPTION
This fixes an issue where each time ember-cli-windows is run on a system that implements set-mppreference, all previous exclusion paths will be replaced by the current exclusion path.  This means that each subsequent use of ember-cli-windows will override the previous usage.

Fixes #41 